### PR TITLE
Made the target es2020

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         {
             "name": "import *",
             "path": "index.js",
-            "limit": "800 B"
+            "limit": "850 B"
         }
     ]
 }

--- a/src/memoryStorage.ts
+++ b/src/memoryStorage.ts
@@ -1,20 +1,20 @@
 class MemoryStorage {
-    #storage = new Map<string, string>();
+    private storage = new Map<string, string>();
 
     getItem(key: string): string | null {
-        if (this.#storage.has(key)) {
-            const value = this.#storage.get(key);
+        if (this.storage.has(key)) {
+            const value = this.storage.get(key);
             return value === undefined ? "undefined" : value;
         }
         return null;
     }
 
     setItem(key: string, value: string): void {
-        this.#storage.set(key, value);
+        this.storage.set(key, value);
     }
 
     removeItem(key: string): void {
-        this.#storage.delete(key);
+        this.storage.delete(key);
     }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "jsx": "react",
-        "target": "ES2022",
+        "target": "ES2020",
         "module": "NodeNext",
         "moduleResolution": "nodenext",
         "esModuleInterop": true,


### PR DESCRIPTION
 - Made the main target to es2020 to confirm to formally support higher number of browsers. (Es2022 isn't really at evergreen level just yet).
 - Made the private variables use typescript private -> This means typescript won't compile those variables to weakmaps variables (which is indeed a bit slower + would make the final build 30bytes bigger).
 - Still the size of the package grew to 801 bytes, 1 byte above the set limit so had to increase that.